### PR TITLE
[Bug] Allow verify_ssl option in VizQL Data Service py client

### DIFF
--- a/python_sdk/CHANGELOG
+++ b/python_sdk/CHANGELOG
@@ -1,3 +1,7 @@
+## 1.1.2 (August 2025)
+
+* Pass verify ssl in VizDataServiceClient to allow the use of custom cert to resolve certificate issue
+
 ## 1.1.1 (June 2025)
 
 * Updates to the README and CONTRIBUTING files
@@ -5,11 +9,3 @@
 ## 1.1.0 (June 2025)
 
 * Initial Release to the world
-
-## 1.1.0 (June 2025)
-
-* Release to Github VizQL-Data-Service repo
-
-## 1.1.1 (Augest 2025)
-
-* Pass verify ssl in VizDataServiceClient to allow the use of custom cert to resolve certificate issue

--- a/python_sdk/CHANGELOG
+++ b/python_sdk/CHANGELOG
@@ -1,3 +1,11 @@
 ## 1.0.0 (April 2025)
 
 * Initial Release to the world
+
+## 1.1.0 (June 2025)
+
+* Release to Github VizQL-Data-Service repo
+
+## 1.1.1 (Augest 2025)
+
+* Pass verify ssl in VizDataServiceClient to allow the use of custom cert to resolve certificate issue

--- a/python_sdk/README.md
+++ b/python_sdk/README.md
@@ -2,14 +2,11 @@
 
 [![Tableau Supported](https://img.shields.io/badge/Support%20Level-Tableau%20Supported-53bd92.svg)](https://www.tableau.com/support-levels-it-and-developer-tools)
 [![GitHub](https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square.svg)](https://raw.githubusercontent.com/tableau/VizQL-Data-Service/refs/heads/main/python_sdk/LICENSE.txt)
-[![Python Version](https://img.shields.io/badge/python-3.9%2B-blue.svg)](https://www.python.org/downloads/)
-<!-- Enable after publish in production
-[![PyPI Version](https://img.shields.io/pypi/v/vizql-data-service-py.svg)](https://pypi.org/project/vizql-data-service-py/)
-[![Downloads](https://img.shields.io/pypi/dm/vizql-data-service-py.svg)](https://pypi.org/project/vizql-data-service-py/)
 [![Build](https://github.com/tableau/VizQL-Data-Service/actions/workflows/push.yml/badge.svg)](https://github.com/tableau/VizQL-Data-Service/actions/workflows/push.yml)
-Add code coverage
--->
+[![PyPI Version](https://img.shields.io/pypi/v/vizql-data-service-py.svg)](https://pypi.org/project/vizql-data-service-py/)
+[![Python Version](https://img.shields.io/badge/python-3.9%2B-blue.svg)](https://www.python.org/downloads/)
 [![OpenAPI](https://img.shields.io/badge/OpenAPI-3.0.3-green.svg)](https://raw.githubusercontent.com/tableau/VizQL-Data-Service/refs/heads/main/VizQLDataServiceOpenAPISchema.json)
+[![Downloads](https://img.shields.io/pypi/dm/vizql-data-service-py.svg)](https://pypi.org/project/vizql-data-service-py/)
 
 The VizQL Data Service Python SDK is a lightweight client library that enables interaction with Tableau's VizQL Data Service APIs. It supports both cloud and on-premises deployments, offering both synchronous and asynchronous methods for querying the VizQL Data Service APIs.
 
@@ -110,6 +107,35 @@ with server.auth.sign_in(tableau_auth):
     )
     print(f"Query Datasource Response: {query_response}")
 ```
+
+### SSL Configuration
+
+If you encounter SSL certificate verification errors (common in corporate environments with VPNs or custom certificates), you can configure SSL verification:
+
+**Options:**
+- `verify_ssl=True` (default): Use system's default CA bundle for SSL verification
+- `verify_ssl=False`: Disable SSL verification entirely 
+- `verify_ssl="/path/to/ca-bundle.pem"`: Use custom CA bundle file
+- `verify_ssl=ssl_context`: Use custom SSL context for advanced configurations
+
+```python
+# Disable SSL verification (for development/testing only)
+client = VizQLDataServiceClient(server_url, server, tableau_auth, verify_ssl=False)
+
+# Use custom CA bundle
+client = VizQLDataServiceClient(server_url, server, tableau_auth, verify_ssl="/path/to/your/ca_bundle.pem")
+
+# Use custom SSL context
+import ssl
+ssl_context = ssl.create_default_context()    
+# Load a custom CA bundle (e.g., for self-signed certificates)
+ssl_context.load_verify_locations(cafile="path/to/your/ca-bundle.pem")
+# Or load client certificates for mutual TLS authentication
+# ssl_context.load_cert_chain(certfile="path/to/your/client.pem", keyfile="path/to/your/client.key")
+client = VizQLDataServiceClient(server_url, server, tableau_auth, verify_ssl=ssl_context)
+```
+
+> **Security Note**: Only disable SSL verification (`verify_ssl=False`) in development or testing environments. For production, use proper SSL certificates or custom CA bundles.
 
 ### API Methods
 The SDK provides two ways to make API calls:

--- a/python_sdk/README.md
+++ b/python_sdk/README.md
@@ -123,13 +123,13 @@ If you encounter SSL certificate verification errors (common in corporate enviro
 client = VizQLDataServiceClient(server_url, server, tableau_auth, verify_ssl=False)
 
 # Use custom CA bundle
-client = VizQLDataServiceClient(server_url, server, tableau_auth, verify_ssl="/path/to/your/ca_bundle.pem")
+client = VizQLDataServiceClient(server_url, server, tableau_auth, verify_ssl="/path/to/ca-bundle.pem")
 
 # Use custom SSL context
 import ssl
 ssl_context = ssl.create_default_context()    
 # Load a custom CA bundle (e.g., for self-signed certificates)
-ssl_context.load_verify_locations(cafile="path/to/your/ca-bundle.pem")
+ssl_context.load_verify_locations(cafile="/path/to/ca-bundle.pem")
 # Or load client certificates for mutual TLS authentication
 # ssl_context.load_cert_chain(certfile="path/to/your/client.pem", keyfile="path/to/your/client.key")
 client = VizQLDataServiceClient(server_url, server, tableau_auth, verify_ssl=ssl_context)

--- a/python_sdk/pyproject.toml
+++ b/python_sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vizql-data-service-py"
-version = "1.1.0"  # This value is manually updated. The major and minor versions must always be the same as the version defined in VizQLDataServiceOpenAPISchema.json
+version = "1.1.1"  # This value is manually updated. The major and minor versions must always be the same as the version defined in VizQLDataServiceOpenAPISchema.json
 
 description = "A Python client library for interacting with the VizQL Data Service API"
 readme = "README.md"

--- a/python_sdk/pyproject.toml
+++ b/python_sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vizql-data-service-py"
-version = "1.1.1"  # This value is manually updated. The major and minor versions must always be the same as the version defined in VizQLDataServiceOpenAPISchema.json
+version = "1.1.2"  # This value is manually updated. The major and minor versions must always be the same as the version defined in VizQLDataServiceOpenAPISchema.json
 
 description = "A Python client library for interacting with the VizQL Data Service API"
 readme = "README.md"

--- a/python_sdk/src/api/client.py
+++ b/python_sdk/src/api/client.py
@@ -182,19 +182,25 @@ class VizQLDataServiceClient:
         url: str,
         server: TSC.Server,
         auth: Union[TSC.JWTAuth, TSC.PersonalAccessTokenAuth, TSC.TableauAuth],
+        verify_ssl: Union[str, bool, ssl.SSLContext] = True,
     ):
         """Initialize the client.
 
         Args:
-            server: The base URL of the server.
+            url: The base URL of the server.
+            server: The Tableau Server instance.
             auth: The authentication object. Can be one of:
                 - TSC.JWTAuth: JWT authentication (--jwt-token)
                 - TSC.PersonalAccessTokenAuth: Personal access token authentication (--pat-name, --pat-secret)
                 - TSC.TableauAuth: Tableau authentication (--user, --password)
+            verify_ssl: Whether or not to verify the SSL certificate of the API server.
+                This should be True in production, but can be set to False for testing purposes.
+                Can also be a path to a CA bundle file or an ssl.SSLContext instance.
         """
         self.url = url
         self.server = server
         self.auth = auth
+        self.verify_ssl = verify_ssl
         self._client = self._create_client()
         self.raise_on_unexpected_status = False
 
@@ -208,6 +214,7 @@ class VizQLDataServiceClient:
             token=self.server.auth_token,
             prefix="",
             auth_header_name=X_TABLEAU_AUTH,
+            verify_ssl=self.verify_ssl,
         )
 
     @property

--- a/python_sdk/tests/test_client.py
+++ b/python_sdk/tests/test_client.py
@@ -1,3 +1,5 @@
+import ssl
+
 import httpx
 import tableauserverclient as TSC
 
@@ -83,6 +85,43 @@ def test_vizql_data_service_client_initialization():
     assert client.server == server
     assert client.auth == auth
     assert isinstance(client._client, AuthenticatedClient)
+
+
+def test_vizql_data_service_client_ssl_configuration():
+    """Test SSL configuration options in VizQLDataServiceClient"""
+    server = TSC.Server("http://test.com")
+    auth = TSC.TableauAuth("test-user", "test-password")
+    server._auth_token = "test-auth-token"
+
+    # Test default SSL verification (True)
+    client_default = VizQLDataServiceClient(
+        url="http://test.com", server=server, auth=auth
+    )
+    assert client_default.verify_ssl is True
+    assert client_default._client._verify_ssl is True
+
+    # Test disabled SSL verification
+    client_disabled = VizQLDataServiceClient(
+        url="http://test.com", server=server, auth=auth, verify_ssl=False
+    )
+    assert client_disabled.verify_ssl is False
+    assert client_disabled._client._verify_ssl is False
+
+    # Test custom CA bundle path
+    ca_bundle_path = "/path/to/ca-bundle.pem"
+    client_ca_bundle = VizQLDataServiceClient(
+        url="http://test.com", server=server, auth=auth, verify_ssl=ca_bundle_path
+    )
+    assert client_ca_bundle.verify_ssl == ca_bundle_path
+    assert client_ca_bundle._client._verify_ssl == ca_bundle_path
+
+    # Test custom SSL context
+    ssl_context = ssl.create_default_context()
+    client_ssl_context = VizQLDataServiceClient(
+        url="http://test.com", server=server, auth=auth, verify_ssl=ssl_context
+    )
+    assert client_ssl_context.verify_ssl == ssl_context
+    assert client_ssl_context._client._verify_ssl == ssl_context
 
 
 def test_vizql_data_service_client_user_agent():


### PR DESCRIPTION
# Pull Request
## Description
Add an optional argument `verify_ssl` in VizQL Data Service client to allow certificate configuration.

Fixes: Fix issue https://github.com/tableau/VizQL-Data-Service/issues/8

## Type of Change

Please delete options that are not relevant.
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (describe):

## Checklist

- [x] I have read the contributing guidelines
- [x] I have added tests where applicable
- [x] I have updated documentation where applicable
- [x] I have added a clear title to this PR
- [x] My changes follow the project's coding style
- [x] I have checked for sensitive information (e.g., no secrets or passwords)
