### PR TITLE
Fix the schema url for VizQL Data Service http endpoint

### DIFF
--- a/VizQLDataServiceOpenAPISchema.json
+++ b/VizQLDataServiceOpenAPISchema.json
@@ -7,7 +7,7 @@
     },
     "servers": [
         {
-        "url": "/vizql-data-service/v1"
+        "url": "/api/v1/vizql-data-service"
         }
     ],
     "paths": {


### PR DESCRIPTION
# Pull Request
## Description
Fix the schema url for VizQL Data Service http endpoint, the old url is internal used only.

Please include a summary of the change and any relevant context. If this is a bug fix, link to the issue. If it's a feature, explain the use case.

Fixes: <!-- e.g. Fixes #123 -->

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (describe):

## Checklist

- [x] I have read the contributing guidelines
- [ ] I have added tests where applicable
- [x] I have updated documentation where applicable
- [x] I have added a clear title to this PR
- [x] My changes follow the project's coding style
- [x] I have checked for sensitive information (e.g., no secrets or passwords)

## Screenshots (if applicable)

_Add screenshots or code snippets if this PR changes UI or major behavior._

## Additional Notes

_Anything else reviewers should know._
